### PR TITLE
Lagt til foresporselompasient-legeerklaring og foresporselompasient-tilleggsopplysninger (kopi av foresporselompasient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ a PDF to your browser. Additionally, the template folder will be fetched on ever
 since the last GET, making this ideal for developing new templates for your application.
 
 The templates and data directory structure both follow the `<application>/<templates>` structure.
-Example url: `http://0.0.0.0:8080/api/v1/genpdf/isbehandlerdialog/foresporselompasient`
+Example url: `http://localhost:8080/api/v1/genpdf/isbehandlerdialog/foresporselompasient-tilleggsopplysninger`

--- a/data/isbehandlerdialog/foresporselompasient-legeerklaring.json
+++ b/data/isbehandlerdialog/foresporselompasient-legeerklaring.json
@@ -1,0 +1,53 @@
+[
+  {
+    "type": "HEADER_H1",
+    "texts": [
+      "Forespørsel om «Legeerklæring ved arbeidsuførhet»"
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Gjelder pasient: Artig Trane, 12345678945"
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Som et ledd i NAVs videre oppfølging av pasienten din har vi behov for informasjon fra deg."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Opplysninger som etter din vurdering faller utenfor formålet, kan du utelate i oversendelsen til NAV."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "«Legeerklæring ved arbeidsuførhet» leveres på blankett NAV 08-07.08, og honoreres med takst L40."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "title": "Lovhjemmel",
+    "texts": [
+      "Folketrygdloven § 21-4 andre ledd gir NAV rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Pålegget om utlevering av opplysninger kan påklages etter forvaltningsloven § 14. Klageadgangen gjelder kun lovligheten av pålegget. Fristen for å klage er tre dager etter at pålegget er mottatt. Klagen kan fremsettes muntlig eller skriftlig."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Med hilsen",
+      "NAV Staden",
+      "Siri Saksbehandler"
+    ]
+  }
+]

--- a/data/isbehandlerdialog/foresporselompasient-tilleggsopplysninger.json
+++ b/data/isbehandlerdialog/foresporselompasient-tilleggsopplysninger.json
@@ -1,0 +1,54 @@
+[
+  {
+    "type": "HEADER_H1",
+    "texts": [
+      "Spørsmål om tilleggsopplysninger vedrørende pasient"
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Gjelder pasient: Artig Trane, 12345678945"
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "NAV trenger opplysninger fra deg vedrørende din pasient. Du kan utelate opplysninger som etter din vurdering faller utenfor formålet."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Her kommer en fritekst skrevet av veilederen, som feks: Artig Trane skal nå vurderes for aktivitetskrav."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Spørsmålene besvares i fritekst, og honoreres med takst L8."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "title": "Lovhjemmel",
+    "texts": [
+      "Folketrygdloven § 21-4 andre ledd gir NAV rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Pålegget om utlevering av opplysninger kan påklages etter forvaltningsloven § 14.",
+      "Klageadgangen gjelder kun lovligheten i pålegget. Fristen for å klage er tre dager etter at pålegget er mottatt. Klagen kan fremsettes muntlig eller skriftlig."
+    ]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": [
+      "Med hilsen",
+      "NAV Staden",
+      "Siri Saksbehandler"
+    ]
+  }
+]

--- a/templates/isbehandlerdialog/foresporselompasient-legeerklaring.hbs
+++ b/templates/isbehandlerdialog/foresporselompasient-legeerklaring.hbs
@@ -1,0 +1,1 @@
+{{> isbehandlerdialog/partials/base items=this doctitle="Forespørsel om pasient"}}

--- a/templates/isbehandlerdialog/foresporselompasient-tilleggsopplysninger.hbs
+++ b/templates/isbehandlerdialog/foresporselompasient-tilleggsopplysninger.hbs
@@ -1,0 +1,1 @@
+{{> isbehandlerdialog/partials/base items=this doctitle="Forespørsel om pasient"}}


### PR DESCRIPTION
Tenkte å fjerne `foresporselompasient` når konsumenten er tilpasset.